### PR TITLE
Expand elm-version range to include 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,14 +1,16 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "summary": "Fuzzy matching and filtering for strings",
     "repository": "https://github.com/NoRedInk/elm-simple-fuzzy.git",
     "license": "BSD3-Clause",
     "source-directories": [
         "src"
     ],
-    "exposed-modules": ["Simple.Fuzzy"],
+    "exposed-modules": [
+        "Simple.Fuzzy"
+    ],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.17.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Turns out the current codebase works with 0.17 as well as 0.18.

cc @joneshf 