### PR TITLE
Cache the correct build-artifacts directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 cache:
   directories:
-    - test/elm-stuff/build-artifacts
+    - tests/elm-stuff/build-artifacts
 
 os:
   - linux


### PR DESCRIPTION
Tests live in `tests/`, not `test/`.